### PR TITLE
Adding support for rendering react components using es6 module exports syntax

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -1,8 +1,11 @@
 'use strict';
 
 require("babel-register")({
-    extensions: [".jsx"],
-    presets: ['react', 'es2015']
+    extensions: ['.jsx'],
+    presets: ['react', 'es2015'],
+    plugins: [
+        'add-module-exports'
+    ]
 });
 
 const Handlebars = require('handlebars');

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "homepage": "https://github.com/frctl/react-adapter",
   "dependencies": {
     "babel-core": "^6.7.0",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-register": "^6.6.5",


### PR DESCRIPTION
Babel now converts the following:

```
export default Component
```

into

```
exports.default = Component
```

Which means that the adapter's render method needs to import es6 components like so:

```
const component = require(path).default;
```

This will break any components written in es5 syntax.

The [plugin added](https://www.npmjs.com/package/babel-plugin-add-module-exports) will fix this issue supporting both ways of writing React components, without modifying the render method.
